### PR TITLE
Change support to elixir 1.14 minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        elixir_version: [1.14, 1.15, 1.16, 1.17]
+        elixir_version: [1.15, 1.16, 1.17]
         otp_version: [ 25, 26, 27]
         exclude:
-          - otp_version: 26
-            elixir_version: 1.14
-          - otp_version: 27
-            elixir_version: 1.14
           - otp_version: 27
             elixir_version: 1.15
           - otp_version: 27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        elixir_version: [1.15]
-        otp_version: [26]
+        elixir_version: [1.14, 1.15, 1.16, 1.17]
+        otp_version: [ 25, 26, 27]
+        exclude:
+          - otp_version: 26
+            elixir_version: 1.14
+          - otp_version: 27
+            elixir_version: 1.14
+          - otp_version: 27
+            elixir_version: 1.15
+          - otp_version: 27
+            elixir_version: 1.16
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.0 (2024-10-01)
+
+* Remove support for Elixir 1.13. Minimum is Elixir 1.14
+
 ## 1.0.0 (2024-02-12)
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -2,13 +2,13 @@ defmodule RedisMutex.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/podium/redis_mutex"
-  @version "1.0.0"
+  @version "1.1.0"
 
   def project do
     [
       app: :redis_mutex,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description:


### PR DESCRIPTION
per coming up deprecation policy, 1.13 will soon be retired to minimum is now 1.14 https://hexdocs.pm/elixir/compatibility-and-deprecations.html